### PR TITLE
add simplecov + coveralls for code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,8 @@ group :development, :test do
   gem 'solr_wrapper', '>= 0.3'
   gem 'rspec-rails'
 end
+
+group :test do
+  gem 'coveralls', require: false
+  gem 'simplecov', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,12 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
     crass (1.0.4)
     daemons (1.2.6)
     database_cleaner (1.7.0)
@@ -186,6 +192,9 @@ GEM
     devise-guests (0.6.0)
       devise
     diff-lcs (1.3)
+    docile (1.3.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.4.0)
     dotenv-rails (2.4.0)
       dotenv (= 2.4.0)
@@ -273,6 +282,8 @@ GEM
       concurrent-ruby (~> 1.0)
     hiredis (0.6.1)
     htmlentities (4.3.4)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     http_logger (0.5.1)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
@@ -487,6 +498,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
+    netrc (0.11.0)
     nio4r (2.3.0)
     noid (0.9.0)
     noid-rails (3.0.0)
@@ -623,6 +635,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.1)
     riiif (1.7.0)
       deprecation (>= 1.0.0)
@@ -694,6 +710,11 @@ GEM
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slop (4.6.2)
     solr_wrapper (1.2.0)
       faraday
@@ -736,9 +757,12 @@ GEM
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
     temple (0.8.0)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    tins (1.16.3)
     tinymce-rails (4.7.11)
       railties (>= 3.1.1)
     turbolinks (5.1.1)
@@ -753,6 +777,9 @@ GEM
     uber (0.1.0)
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.6.2)
@@ -780,6 +807,7 @@ DEPENDENCIES
   capistrano-sidekiq (~> 0.20.0)
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  coveralls
   database_cleaner
   devise
   devise-guests (~> 0.6)
@@ -797,6 +825,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
+  simplecov
   solr_wrapper (>= 0.3)
   sqlite3
   turbolinks (~> 5)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,14 @@ require 'rspec/rails'
 require 'active_fedora/cleaner'
 require 'database_cleaner'
 
+if ENV['COVERAGE'] || ENV['TRAVIS']
+  require 'simplecov'
+  require 'coveralls'
+  
+  SimpleCov.formatter = Coveralls::SimpleCov::Formatter if ENV['TRAVIS']
+  SimpleCov.start 'rails'
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
This installs SimpleCov and Coveralls gems to enable code-coverage
reporting. Coverage is calculated only when the environment
variables `COVERAGE` or `TRAVIS` are set.